### PR TITLE
allow domfuzz to work.

### DIFF
--- a/src/fuzzfetch/fetch.py
+++ b/src/fuzzfetch/fetch.py
@@ -627,6 +627,10 @@ class Fetcher(object):
 
         try:
             obj.extract_build(out_tmp, tests=extract_args['tests'], full_symbols=extract_args['full_symbols'])
+            os.makedirs(os.path.join(out_tmp, 'download'))
+            with open(os.path.join(out_tmp, 'download', 'firefox-temp.txt'), 'a') as f:
+                f.write('buildID={}{}'.format(obj.build_id,. os.linesep))
+
             shutil.move(os.path.join(out_tmp), extract_args['out'])
         finally:
             if os.path.isdir(out_tmp):

--- a/src/fuzzfetch/fetch.py
+++ b/src/fuzzfetch/fetch.py
@@ -629,7 +629,7 @@ class Fetcher(object):
             obj.extract_build(out_tmp, tests=extract_args['tests'], full_symbols=extract_args['full_symbols'])
             os.makedirs(os.path.join(out_tmp, 'download'))
             with open(os.path.join(out_tmp, 'download', 'firefox-temp.txt'), 'a') as f:
-                f.write('buildID={}{}'.format(obj.build_id,. os.linesep))
+                f.write('buildID={}{}'.format(obj.build_id, os.linesep))
 
             shutil.move(os.path.join(out_tmp), extract_args['out'])
         finally:


### PR DESCRIPTION
without this fix, domfuzz fails as follows:
 Traceback (most recent call last):
  File "/domfuzz/dom/automation/loopdomfuzz.py", line 261, in <module>
     start_runs()
  File "/domfuzz/dom/automation/loopdomfuzz.py", line 258, in start_runs
     many_timed_runs(None, sps.createWtmpDir(os.getcwdu()), sys.argv[1:], collector, quiet=False)
   File "/domfuzz/dom/automation/loopdomfuzz.py", line 61, in many_timed_runs
     bc = domInteresting.BrowserConfig(args, collector)
   File "/domfuzz/dom/automation/domInteresting.py", line 509, in __init__
    self.dirs = FigureOutDirs(getFullPath(browserDir))
  File "/domfuzz/dom/automation/domInteresting.py", line 405, in __init__
     self.hgRev = downloadedBuildRev(browserDir)
  File "/domfuzz/dom/automation/domInteresting.py", line 442, in downloadedBuildRev
     for fn in os.listdir(downloadDir):
