### PR TITLE
Use build_id instead of rank in directory name

### DIFF
--- a/src/fuzzfetch/fetch.py
+++ b/src/fuzzfetch/fetch.py
@@ -298,7 +298,7 @@ class Fetcher(object):
             options = build.split(self.moz_info["platform_guess"], 1)[1]
         else:
             options = self._flags.build_string()
-        self._auto_name = 'm-%s-%d%s' % (self._branch[0], self.rank, options)
+        self._auto_name = 'm-%s-%s%s' % (self._branch[0], self.build_id, options)
 
     @classmethod
     def iterall(cls, target, branch, build, flags, arch_32=False):


### PR DESCRIPTION
Rank is not always a useful value. For example on Windows ASan builds is it 0. Using build_id will always be a useful value and it has the benefit of also being human readable. This also makes it easy to tell if you have old builds laying around.

Is there any reason to not switch over? Is there something that requires the current formatting?