### PR TITLE
Cross-platform support (--os/--cpu) and Android

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,4 +39,4 @@ if __name__ == "__main__":
         package_dir={"": "src"},
         packages=["fuzzfetch"],
         url="https://github.com/MozillaSecurity/fuzzfetch",
-        version="0.6.0")
+        version="0.7.0")


### PR DESCRIPTION
Example download for Android:

```
$ fuzzfetch --os Android --cpu x86 -d --fuzzing
[2018-09-05 15:24:53] Identified task: https://index.taskcluster.net/v1//task/gecko.v2.mozilla-central.latest.mobile.android-x86-fuzzing-debug
[2018-09-05 15:24:53] > Task ID: GnSdA1bjSECc722LvaQyeQ
[2018-09-05 15:24:53] > Rank: 1536171209
[2018-09-05 15:24:53] > Changeset: e401d1d666005bcf9ccf7fb9f9aa3256b9446544
[2018-09-05 15:24:53] > Build ID: 20180905181329
[2018-09-05 15:24:54] > Downloading: https://queue.taskcluster.net/v1/task/GnSdA1bjSECc722LvaQyeQ/artifacts/public/build/target.apk (42.23MB total)
[2018-09-05 15:24:56] .. downloaded (14.28MB/s)
[2018-09-05 15:24:57] > Downloading: https://queue.taskcluster.net/v1/task/GnSdA1bjSECc722LvaQyeQ/artifacts/public/build/target.crashreporter-symbols.zip (86.90MB total)
[2018-09-05 15:25:00] .. downloaded (20.96MB/s)
[2018-09-05 15:25:00] .. extracting
$ ls m-c-20180905181329-fuzzing-debug
dist  download  symbols  target.apk  target.apk.fuzzmanagerconf
$
```

Note: `--32` is replaced by `--cpu x86`

I updated the taskcluster-mocked tests as well (such as they are), but I'll add that post-review, since they are enormous.