### PR TITLE
Hide 7z output

### DIFF
--- a/src/fuzzfetch/extract.py
+++ b/src/fuzzfetch/extract.py
@@ -77,7 +77,8 @@ def extract_tar(tar_fn, mode='', path='.'):
     try:
         if P7Z_PATH and mode in {'7z', 'bz2', 'gz', 'lzma', 'xz'}:
             p7z_fd, p7z_fn = tempfile.mkstemp(prefix='fuzzfetch-', suffix='.tar')
-            result = subprocess.call([P7Z_PATH, 'e', '-so', tar_fn], stdout=p7z_fd)
+            with open(os.devnull, "w") as devnull:
+                result = subprocess.call([P7Z_PATH, 'e', '-so', tar_fn], stdout=p7z_fd, stderr=devnull)
             os.close(p7z_fd)
             if result == 0:
                 mode = ''


### PR DESCRIPTION
I assume there is no reason to show the 7z output?
```
...
[2019-11-15 17:05:50] .. extracting

7-Zip [64] 9.20  Copyright (c) 1999-2010 Igor Pavlov  2010-11-18
p7zip Version 9.20 (locale=en_CA.UTF-8,Utf16=on,HugeFiles=on,8 CPUs)

Processing archive: /tmp/fuzzfetch-64vDFf.tar.bz2

Extracting  fuzzfetch-64vDFf.tar

Everything is Ok

Size:       0
Compressed: 71309471
...
```