### PR TITLE
Ensure nearest ranges use the minimal boundary

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ statistics = true
 [metadata]
 description-file = README.md
 name = fuzzfetch
-version = 0.9.6
+version = 0.9.7
 license = MPL 2.0
 url = https://github.com/MozillaSecurity/fuzzfetch
 maintainer = Mozilla Fuzzing Team

--- a/src/fuzzfetch/fetch.py
+++ b/src/fuzzfetch/fetch.py
@@ -456,8 +456,8 @@ class Fetcher(object):
 
                 # If start date is outside the range of the newest/oldest available build, adjust it
                 if asc:
-                    start = max(start, now - timedelta(days=364))
-                    end = min(start, now)
+                    start = min(max(start, now - timedelta(days=364)), now)
+                    end = now
                 else:
                     end = now - timedelta(days=364)
                     start = max(min(start, now), end)

--- a/src/fuzzfetch/fetch.py
+++ b/src/fuzzfetch/fetch.py
@@ -457,12 +457,12 @@ class Fetcher(object):
                 # If start date is outside the range of the newest/oldest available build, adjust it
                 if asc:
                     start = max(start, now - timedelta(days=364))
-                    end = now
+                    end = min(start, now)
                 else:
-                    start = min(start, now)
                     end = now - timedelta(days=364)
+                    start = max(min(start, now), end)
 
-                while start < end if asc else start > end:
+                while start <= end if asc else start >= end:
                     try:
                         self._task = BuildTask(start.strftime('%Y-%m-%d'), branch, self._flags, self._platform)
                         break


### PR DESCRIPTION
Nearest search may fail if start and end boundaries exceed valid range.  This PR locks these boundaries to the earliest/latest available build.