### PR TITLE
Organize argparser in exported class

### DIFF
--- a/src/fuzzfetch/fetch.py
+++ b/src/fuzzfetch/fetch.py
@@ -429,7 +429,7 @@ class FetcherArgs(object):
         @param args: a list of arguments
         """
         if hasattr(super(FetcherArgs, self), 'sanity_check'):
-            super(FetcherArgs, self).sanity_check(args)
+            super(FetcherArgs, self).sanity_check(args)  # pylint: disable=no-member
 
         if self.build_is_ns:
             # this is a custom build

--- a/src/fuzzfetch/fetch.py
+++ b/src/fuzzfetch/fetch.py
@@ -341,7 +341,10 @@ class FetcherArgs(object):
         """
         Instantiate a new FetcherArgs instance
         """
-        self.parser = argparse.ArgumentParser()
+        super(FetcherArgs, self).__init__()
+        if not hasattr(self, "parser"):
+            self.parser = argparse.ArgumentParser(conflict_handler='resolve')
+
         self.parser.set_defaults(target='firefox', build='latest', tests=None)  # branch default is set after parsing
 
         target_group = self.parser.add_argument_group('Target')

--- a/src/fuzzfetch/fetch.py
+++ b/src/fuzzfetch/fetch.py
@@ -971,7 +971,7 @@ class Fetcher(object):
 
         final_dir = os.path.realpath(os.path.join(args.out, args.name))
         if not skip_dir_check and os.path.exists(final_dir):
-            parser.error('Folder exists: %s .. exiting' % final_dir)
+            parser.parser.error('Folder exists: %s .. exiting' % final_dir)
 
         extract_options = {
             'dry_run': args.dry_run,

--- a/src/fuzzfetch/fetch.py
+++ b/src/fuzzfetch/fetch.py
@@ -971,7 +971,7 @@ class Fetcher(object):
 
         final_dir = os.path.realpath(os.path.join(args.out, args.name))
         if not skip_dir_check and os.path.exists(final_dir):
-            raise FetcherException('Folder exists: %s .. exiting' % final_dir)
+            parser.error('Folder exists: %s .. exiting' % final_dir)
 
         extract_options = {
             'dry_run': args.dry_run,

--- a/src/fuzzfetch/fetch.py
+++ b/src/fuzzfetch/fetch.py
@@ -28,7 +28,7 @@ from .extract import extract_dmg, extract_tar, extract_zip
 from .path import rmtree as junction_rmtree, onerror
 
 
-__all__ = ( "BuildFlags", "BuildTask", "Fetcher", "FetcherArgs", "FetcherException")
+__all__ = ("BuildFlags", "BuildTask", "Fetcher", "FetcherArgs", "FetcherException")
 
 
 LOG = logging.getLogger('fuzzfetch')

--- a/src/fuzzfetch/fetch.py
+++ b/src/fuzzfetch/fetch.py
@@ -428,6 +428,9 @@ class FetcherArgs(object):
         @type args: list
         @param args: a list of arguments
         """
+        if hasattr(super(FetcherArgs, self), 'sanity_check'):
+            super(FetcherArgs, self).sanity_check(args)
+
         if self.build_is_ns:
             # this is a custom build
             # ensure conflicting options are not set


### PR DESCRIPTION
This PR refactors existing arg parser into an exportable class.  This allows other projects that leverage fuzzfetch to import the argument parsing and sanity checks without having to duplicate it elsewhere.