### PR TITLE
Add support for autoland builds

### DIFF
--- a/src/fuzzfetch/fetch.py
+++ b/src/fuzzfetch/fetch.py
@@ -76,7 +76,11 @@ class HgRevision(object):
         """
         if branch is None or branch == '?':
             raise FetcherException("Can't lookup revision date for branch: %r" % (branch,))
-        if branch != 'try':
+        if branch == 'try':
+            pass
+        elif branch in ('autoland', 'inbound'):
+            branch = 'integration/' + branch
+        else:
             branch = 'mozilla-' + branch
         self._data = _get_url('https://hg.mozilla.org/%s/json-rev/%s' % (branch, revision)).json()
 
@@ -251,8 +255,8 @@ class BuildTask(object):
             task_template_paths = itertools.product(cls.TASKCLUSTER_APIS, task_paths)
 
         elif build == 'latest':
-            if branch == 'try':
-                namespace = 'gecko.v2.try.latest'
+            if branch in ('autoland', 'try'):
+                namespace = 'gecko.v2.' + branch + '.latest'
             else:
                 namespace = 'gecko.v2.mozilla-' + branch + '.latest'
             product = 'mobile' if 'android' in target_platform else 'firefox'
@@ -300,7 +304,7 @@ class BuildTask(object):
     @classmethod
     def _pushdate_template_paths(cls, pushdate, branch, target_platform):
         """Multiple entries exist per push date. Iterate over all until a working entry is found"""
-        if branch != 'try':
+        if branch not in ('autoland', 'try'):
             branch = 'mozilla-' + branch
         path = '/namespaces/gecko.v2.' + branch + '.pushdate.' + pushdate
         date_found = False
@@ -379,6 +383,8 @@ class FetcherArgs(object):
         branch_args.add_argument('--esr-next', action='store_const', const='esr-next', dest='branch',
                                  help='Download from esr-next')
         branch_args.add_argument('--try', action='store_const', const='try', dest='branch',
+                                 help='Download from try')
+        branch_args.add_argument('--autoland', action='store_const', const='autoland', dest='branch',
                                  help='Download from try')
 
         build_group = self.parser.add_argument_group('Build Arguments')

--- a/src/fuzzfetch/fetch.py
+++ b/src/fuzzfetch/fetch.py
@@ -76,11 +76,9 @@ class HgRevision(object):
         """
         if branch is None or branch == '?':
             raise FetcherException("Can't lookup revision date for branch: %r" % (branch,))
-        if branch == 'try':
-            pass
-        elif branch in ('autoland', 'inbound'):
+        if branch in {'autoland', 'inbound'}:
             branch = 'integration/' + branch
-        else:
+        elif branch != 'try':
             branch = 'mozilla-' + branch
         self._data = _get_url('https://hg.mozilla.org/%s/json-rev/%s' % (branch, revision)).json()
 
@@ -255,7 +253,7 @@ class BuildTask(object):
             task_template_paths = itertools.product(cls.TASKCLUSTER_APIS, task_paths)
 
         elif build == 'latest':
-            if branch in ('autoland', 'try'):
+            if branch in {'autoland', 'try'}:
                 namespace = 'gecko.v2.' + branch + '.latest'
             else:
                 namespace = 'gecko.v2.mozilla-' + branch + '.latest'
@@ -304,7 +302,7 @@ class BuildTask(object):
     @classmethod
     def _pushdate_template_paths(cls, pushdate, branch, target_platform):
         """Multiple entries exist per push date. Iterate over all until a working entry is found"""
-        if branch not in ('autoland', 'try'):
+        if branch not in {'autoland', 'try'}:
             branch = 'mozilla-' + branch
         path = '/namespaces/gecko.v2.' + branch + '.pushdate.' + pushdate
         date_found = False


### PR DESCRIPTION
Adds support for autoland builds and fixes a bug in retrieving the pushdate and hash for inbound builds (both use integration/branch).

I didn't include autoland in the tests since we don't test every branch but if you want, I'll add it.