### PR TITLE
Support fuzzing-debug builds without crashreporter-symbols.zip

### DIFF
--- a/src/fuzzfetch/fetch.py
+++ b/src/fuzzfetch/fetch.py
@@ -793,7 +793,13 @@ class Fetcher(object):
 
         if not self._flags.asan and not self._flags.tsan and not self._flags.valgrind:
             os.mkdir(os.path.join(path, 'symbols'))
-            self.extract_zip('crashreporter-symbols.zip', path=os.path.join(path, 'symbols'))
+            try:
+                self.extract_zip('crashreporter-symbols.zip', path=os.path.join(path, 'symbols'))
+            except FetcherException:
+                # fuzzing debug builds no longer have crashreporter-symbols.zip (bug 1649062)
+                # we want to maintain support for older builds for now
+                if not (self._flags.debug and self._flags.fuzzing):
+                    raise
 
         self._write_fuzzmanagerconf(path)
 


### PR DESCRIPTION
This will fix issue #70. 