### PR TITLE
Don't resolve_esr if build is a namespace

### DIFF
--- a/src/fuzzfetch/fetch.py
+++ b/src/fuzzfetch/fetch.py
@@ -1226,11 +1226,11 @@ class Fetcher(object):
 
         # do this default manually so we can error if combined with --build namespace
         # parser.set_defaults(branch='central')
-        if not parser.is_build_ns(args.build) and args.branch is None:
-            args.branch = "central"
-
-        if args.branch.startswith("esr"):
-            args.branch = Fetcher.resolve_esr(args.branch)
+        if not parser.is_build_ns(args.build):
+            if args.branch is None:
+                args.branch = "central"
+            elif args.branch.startswith("esr"):
+                args.branch = Fetcher.resolve_esr(args.branch)
 
         flags = BuildFlags(
             args.asan, args.tsan, args.debug, args.fuzzing, args.coverage, args.valgrind


### PR DESCRIPTION
Using a namespace throws with:

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/forb1dden/tools/fuzzfetch/src/fuzzfetch/__main__.py", line 9, in <module>
    Fetcher.main()
  File "/home/forb1dden/tools/fuzzfetch/src/fuzzfetch/fetch.py", line 1279, in main
    obj, extract_args = cls.from_args()
  File "/home/forb1dden/tools/fuzzfetch/src/fuzzfetch/fetch.py", line 1232, in from_args
    if args.branch.startswith("esr"):
AttributeError: 'NoneType' object has no attribute 'startswith'
```