### PR TITLE
Add autoland to branch search regex

### DIFF
--- a/src/fuzzfetch/fetch.py
+++ b/src/fuzzfetch/fetch.py
@@ -871,8 +871,8 @@ class Fetcher(object):
             options = build.split(self.moz_info["platform_guess"], 1)[1]
         else:
             options = self._flags.build_string()
-        if self._branch == "try":
-            branch = "try"
+        if self._branch in {"autoland", "try"}:
+            branch = self._branch
         else:
             branch = "m-%s" % (self._branch[0],)
         self._auto_name = "%s%s-%s%s" % (

--- a/src/fuzzfetch/fetch.py
+++ b/src/fuzzfetch/fetch.py
@@ -705,7 +705,7 @@ class Fetcher(object):
                 # If branch wasn't set, try and retrieve it from the build string
                 if self._branch is None:
                     branch = re.search(
-                        r"\.(try|mozilla-(?P<branch>[a-z]+[0-9]*))\.", build
+                        r"\.(autoland|try|mozilla-(?P<branch>[a-z]+[0-9]*))\.", build
                     )
                     self._branch = branch.group("branch") if branch is not None else "?"
                     if self._branch is None:


### PR DESCRIPTION
This is necessary when using an autoland namespace.

```
python -m fuzzfetch --build gecko.v2.autoland.revision.00082591503eb5e57cce27f722b8a45c943c7034.firefox.linux64-asan-opt
[2021-02-10 19:06:11] Identified task: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.autoland.revision.00082591503eb5e57cce27f722b8a45c943c7034.firefox.linux64-asan-opt
...
[2021-02-10 19:07:52] Extracted into /home/user/builds/m-?-20200527140754-opt
