### PR TITLE
Update fuzzfetch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,22 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.6.4
+    rev: 5.8.0
     hooks:
       - id: isort
   - repo: https://github.com/asottile/yesqa
-    rev: v1.2.2
+    rev: v1.2.3
     hooks:
       - id: yesqa
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 21.5b1
     hooks:
       - id: black
-  - repo: https://github.com/pycqa/pylint
-    rev: pylint-2.6.0
-    hooks:
-      - id: pylint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.2
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-ast
       - id: check-docstring-first
@@ -51,6 +47,14 @@ repos:
   - repo: meta
     hooks:
       - id: check-useless-excludes
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: tox -e pylint --
+        language: system
+        require_serial: true
+        types: [python]
 
 default_language_version:
   python: python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ disable = [
     "C0326",
     "bad-continuation",
     "fixme",
-    "import-error",
     "subprocess-run-check",
     "too-few-public-methods",
     "too-many-arguments",

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -4,8 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import itertools
 import logging
 import time
@@ -251,17 +249,17 @@ def test_metadata(branch, build_flags, os_, cpu):
 @pytest.mark.parametrize(
     "requested, expected, direction",
     (
-        ("2019-11-06", "2019-11-07", fuzzfetch.Fetcher.BUILD_ORDER_ASC),
-        ("2020-08-06", "2020-08-05", fuzzfetch.Fetcher.BUILD_ORDER_DESC),
+        ("2019-11-06", "2019-11-07", fuzzfetch.BuildSearchOrder.ASC),
+        ("2020-08-06", "2020-08-05", fuzzfetch.BuildSearchOrder.DESC),
         (
             "d271c572a9bcd008ed14bf104b2eb81949952e4c",
             "ac63c8962183502a4b0ec32222efc67d3841d157",
-            fuzzfetch.Fetcher.BUILD_ORDER_ASC,
+            fuzzfetch.BuildSearchOrder.ASC,
         ),
         (
             "d271c572a9bcd008ed14bf104b2eb81949952e4c",
             "e8b7c48d4e7ed1b63aeedff379b51e566ea499d9",
-            fuzzfetch.Fetcher.BUILD_ORDER_DESC,
+            fuzzfetch.BuildSearchOrder.DESC,
         ),
     ),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -33,15 +33,16 @@ skip_install = true
 
 [testenv:lint]
 commands =
-    isort {toxinidir}
-    black {toxinidir}
-    pylint {toxinidir}/src/fuzzfetch
-    flake8 {toxinidir}
+    pre-commit run -a
 deps =
-    black
-    flake8
-    isort
-    pylint
+    pre-commit
+skip_install = true
+
+[testenv:pylint]
+commands =
+    pylint {posargs}
+deps =
+    pylint==2.8.2
 usedevelop = true
 
 [testenv:pypi]


### PR DESCRIPTION
* add typing hints for all functions
* use an enum for build search order
* support pathlib consistently
* update linters to be consistent between pre-commit & tox
* drop compatibility code for unsupported versions