### PR TITLE
Add support for lbzip2 and tar

### DIFF
--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -4,12 +4,14 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import tarfile
+from unittest.mock import patch
 
 import pytest  # pylint: disable=import-error
 
 from fuzzfetch.extract import extract_tar
 
 
+@patch("fuzzfetch.extract.TAR_PATH", None)
 def test_tarfile_good(tmp_path):
     """basic extract_tar functions"""
     (tmp_path / "empty").touch()
@@ -23,6 +25,7 @@ def test_tarfile_good(tmp_path):
     }
 
 
+@patch("fuzzfetch.extract.TAR_PATH", None)
 def test_tarfile_traversal_exc(tmp_path):
     """CVE-2007-4559"""
     (tmp_path / "empty").touch()


### PR DESCRIPTION
I had an old branch to profile extraction methods so I could choose the fastest. Rebased and ran, I got the following results:

```
[2022-11-21 14:31:45] profiling 7z:zip
[2022-11-21 14:31:58]  > mean: 66.32ms stdev: 1.2865ms (100 iterations)
[2022-11-21 14:31:58] profiling unzip
[2022-11-21 14:32:16]  > mean: 194.75ms stdev: 2.0681ms (50 iterations)
[2022-11-21 14:32:16] profiling py:zipfile
[2022-11-21 14:32:29]  > mean: 64.43ms stdev: 1.9492ms (100 iterations)
[2022-11-21 14:32:29]
[2022-11-21 14:32:29] profiling tar
[2022-11-21 14:32:42]  > mean: 27.96ms stdev: 0.4993ms (200 iterations)
[2022-11-21 14:32:42] profiling py:tarfile
[2022-11-21 14:32:53]  > mean: 53.34ms stdev: 2.3217ms (100 iterations)
[2022-11-21 14:32:53]
[2022-11-21 14:32:53] profiling 7z:bz2
[2022-11-21 14:33:02]  > mean: 1.05s stdev: 0.0042s (5 iterations)
[2022-11-21 14:33:02] profiling lbzip2
[2022-11-21 14:33:19]  > mean: 459.00ms stdev: 11.1529ms (20 iterations)
[2022-11-21 14:33:19] profiling bzip2
[2022-11-21 14:33:36]  > mean: 2.17s stdev: 0.0446s (5 iterations)
[2022-11-21 14:33:36] profiling py:bz2
[2022-11-21 14:33:45]  > mean: 1.05s stdev: 0.0067s (5 iterations)
[2022-11-21 14:33:45]
[2022-11-21 14:33:45] profiling 7z:gz
[2022-11-21 14:34:04]  > mean: 218.65ms stdev: 1.8175ms (50 iterations)
[2022-11-21 14:34:04] profiling gzip
[2022-11-21 14:34:25]  > mean: 232.41ms stdev: 1.3763ms (50 iterations)
[2022-11-21 14:34:25] profiling py:gz
[2022-11-21 14:34:36]  > mean: 131.77ms stdev: 0.9630ms (50 iterations)
```

The fastest results then are:
zip -> python zipfile (~33% of unzip cli, no difference with 7z)
tar -> tar (~50% of python tarfile)
bz2 -> lbzip2 (~50% of python bzip2, no difference between python bzip2 & 7z)
gz -> python gzip (~50% of 7z & gzip cli)


The results for python's zipfile, bzip2 and gzip vs 7z are much better than in the past (we originally supported python 2.7).

Putting it together, this speeds up real build extraction as follows (single test on Linux):

```
(linux64 fuzzing-asan-opt)
target.tar.bz2
    old (7z + py:tarfile): 17s
    new (lbzip2 + tar): 9s
target.gtest.tests.tar.gz
    old (7z + py:tarfile): 11s
    new (py:gzip + tar): 8s

(win64 fuzzing-asan-opt)
target.zip
    old (7z): 7s
    new (py:zipfile): 5s
```