### PR TITLE
Add support for downloading mozharness

### DIFF
--- a/src/fuzzfetch/args.py
+++ b/src/fuzzfetch/args.py
@@ -37,7 +37,7 @@ class FetcherArgs:
             nargs="*",
             default=FetcherArgs.DEFAULT_TARGETS,
             help="Specify the build artifacts to download. "
-            "Valid options: firefox js common gtest "
+            "Valid options: firefox js common gtest mozharness"
             f"(default: {' '.join(FetcherArgs.DEFAULT_TARGETS)})",
         )
         target_group.add_argument(


### PR DESCRIPTION
Required refactoring the `extract_zip` and `extract_tar` methods to accept a full URL as `mozharness.zip` isn't prefixed with the typical `target.{path}.zip` suffix.