### PR TITLE
Include only expected events and actions

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -79,7 +79,10 @@ tasks:
           base: {$eval: event.pull_request.base}
 
   in:
-    $if: 'tasks_for != "github-pull-request" || event["action"] in ["opened", "reopened", "synchronize"]'
+    $if: >
+      (tasks_for == "github-push")
+      || (tasks_for == "github-pull-request" && event["action"] in ["opened", "reopened", "synchronize"])
+      || (tasks_for == "github-release" && event["action"] in ["published"])
     then:
       - created: {$fromNow: ''}
         deadline: {$fromNow: '1 hour'}
@@ -113,3 +116,4 @@ tasks:
           description: Schedule CI tasks for ${project_name}
           owner: truber@mozilla.com
           source: https://github.com/MozillaSecurity/orion
+    else: []


### PR DESCRIPTION
During recent incident where `release` build was cancelled it was discovered that multiple task graphs are being created:

-    02344790-61f0-11ee-9b3b-bf21df2e33e8 at 2023-10-03 13:23:16.945+00 (action: published)
-    022ef060-61f0-11ee-8808-d2c41dba997b at 2023-10-03 13:23:17.006+00 (action: created)
-    02281290-61f0-11ee-9434-9981115b9963 at 2023-10-03 13:23:17.059+00 (action: released)

each of them resulted in creation of separate task groups: `eAhvf8KjSNW6pcYYjaIPfA`, `Nio-_qsrRcK5OQGH09TygQ`, `TfFA22PTQIWCKQbhHi14qg`

Taskcluster Github service was patched to fix this issue where it shouldn't be cancelling release events at all: https://github.com/taskcluster/taskcluster/pull/6595 

And I think it is also important not to create additional builds for extra release events.

