### PR TITLE
Update decompression

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -50,6 +50,16 @@ tasks:
             version: "3.12"
             env:
               TOXENV: py312,lint
+          - name: tests python 3.9 (macos)
+            version: "3.9"
+            platform: macos
+            env:
+              TOXENV: py39
+          - name: test python 3.9 (windows)
+            version: "3.9"
+            platform: windows
+            env:
+              TOXENV: py39
           - name: PyPI upload
             version: "3.11"
             env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ disable = [
     "too-many-lines",
     "too-many-locals",
     "too-many-nested-blocks",
+    "too-many-positional-arguments",
     "too-many-statements",
     "unspecified-encoding",
 ]

--- a/src/fuzzfetch/args.py
+++ b/src/fuzzfetch/args.py
@@ -3,13 +3,14 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 """Fuzzfetch argument parser"""
 
+from __future__ import annotations
+
 import itertools
 import platform as std_platform
 from argparse import ArgumentParser, Namespace
 from collections.abc import Sequence
 from logging import getLogger
 from pathlib import Path
-from typing import Optional
 
 from .models import BuildSearchOrder, Platform
 from .utils import extract_branch_from_ns, is_namespace
@@ -187,7 +188,7 @@ class FetcherArgs:
         if "js" not in args.target and args.sim:
             self.parser.error("Simulator builds are only available for JS targets")
 
-    def parse_args(self, argv: Optional[Sequence[str]] = None) -> Namespace:
+    def parse_args(self, argv: Sequence[str] | None = None) -> Namespace:
         """Parse and validate args
 
         Arguments:

--- a/src/fuzzfetch/core.py
+++ b/src/fuzzfetch/core.py
@@ -3,6 +3,8 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 """Core fuzzfetch implementation"""
 
+from __future__ import annotations
+
 import configparser
 import logging
 import os
@@ -14,7 +16,7 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any
 
 from pytz import timezone
 
@@ -47,12 +49,12 @@ class Fetcher:
     def __init__(
         self,
         branch: str,
-        build: Union[str, BuildTask],
-        flags: Union[Sequence[bool], BuildFlags],
+        build: str | BuildTask,
+        flags: Sequence[bool] | BuildFlags,
         targets: Sequence[str],
-        platform: Optional[Platform] = None,
-        simulated: Optional[str] = None,
-        nearest: Optional[BuildSearchOrder] = None,
+        platform: Platform | None = None,
+        simulated: str | None = None,
+        nearest: BuildSearchOrder | None = None,
     ) -> None:
         """
         Arguments:
@@ -276,7 +278,7 @@ class Fetcher:
         return self.build_info["moz_source_stamp"]
 
     @property
-    def moz_info(self) -> dict[str, Union[str, bool, int]]:
+    def moz_info(self) -> dict[str, str | bool | int]:
         """Return the build's mozinfo"""
         if "moz_info" not in self._memo:
             try:
@@ -661,9 +663,9 @@ class Fetcher:
     @classmethod
     def from_args(
         cls,
-        argv: Optional[Sequence[str]] = None,
+        argv: Sequence[str] | None = None,
         skip_dir_check: bool = False,
-    ) -> tuple["Fetcher", dict[str, Union[bool, Path, Sequence[str]]]]:
+    ) -> tuple[Fetcher, dict[str, bool | Path | Sequence[str]]]:
         """Construct a Fetcher from given command line arguments.
 
         Arguments:

--- a/src/fuzzfetch/download.py
+++ b/src/fuzzfetch/download.py
@@ -3,9 +3,10 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 """Fuzzfetch download utils"""
 
+from __future__ import annotations
+
 import time
 from logging import getLogger
-from typing import Optional, Union
 
 from requests import Response, Session
 from requests.exceptions import RequestException
@@ -17,7 +18,7 @@ HTTP_SESSION = Session()
 LOG = getLogger("fuzzfetch")
 
 
-def iec(number: Union[float, int]) -> str:
+def iec(number: float | int) -> str:
     """Format a number using IEC multi-byte prefixes.
 
     Arguments:
@@ -33,7 +34,7 @@ def iec(number: Union[float, int]) -> str:
     return f"{number:0.2f}{prefixes[0]}"
 
 
-def si(number: Union[float, int]) -> str:  # pylint: disable=invalid-name
+def si(number: float | int) -> str:  # pylint: disable=invalid-name
     """Format a number using SI prefixes.
 
     Arguments:
@@ -49,7 +50,7 @@ def si(number: Union[float, int]) -> str:  # pylint: disable=invalid-name
     return f"{number:0.2f}{prefixes[0]}"
 
 
-def get_url(url: str, timeout: Optional[float] = None) -> Response:
+def get_url(url: str, timeout: float | None = None) -> Response:
     """Retrieve requested URL"""
     try:
         data = HTTP_SESSION.get(url, stream=True, timeout=timeout)
@@ -60,7 +61,7 @@ def get_url(url: str, timeout: Optional[float] = None) -> Response:
     return data
 
 
-def resolve_url(url: str, timeout: Optional[float] = None) -> Response:
+def resolve_url(url: str, timeout: float | None = None) -> Response:
     """Resolve requested URL"""
     try:
         data = HTTP_SESSION.head(url, timeout=timeout)
@@ -71,7 +72,7 @@ def resolve_url(url: str, timeout: Optional[float] = None) -> Response:
     return data
 
 
-def download_url(url: str, outfile: PathArg, timeout: Optional[float] = 30.0) -> None:
+def download_url(url: str, outfile: PathArg, timeout: float | None = 30.0) -> None:
     """Download a URL to a local path.
 
     Arguments:

--- a/src/fuzzfetch/extract.py
+++ b/src/fuzzfetch/extract.py
@@ -20,10 +20,10 @@ from .path import PathArg, onerror
 
 LOG = logging.getLogger("fuzzfetch")
 
-
 HDIUTIL_PATH = shutil.which("hdiutil")
 TAR_PATH = shutil.which("tar") if system() != "Darwin" else shutil.which("gtar")
 LBZIP2_PATH = shutil.which("lbzip2")
+XZ_PATH = shutil.which("xz")
 
 
 def extract_zip(zip_fn: PathArg, path: PathArg = ".") -> None:

--- a/src/fuzzfetch/extract.py
+++ b/src/fuzzfetch/extract.py
@@ -2,9 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 """Code for extracting archives"""
+from __future__ import annotations
 
 import gzip
 import logging
+import lzma
 import os
 import os.path
 import shutil
@@ -14,7 +16,7 @@ import tempfile
 import zipfile
 from pathlib import Path
 from platform import system
-from subprocess import DEVNULL, call, check_call
+from subprocess import PIPE, CalledProcessError, Popen, check_call, run
 
 from .path import PathArg, onerror
 
@@ -81,59 +83,79 @@ def extract_tar(tar_fn: PathArg, mode: str = "", path: PathArg = ".") -> None:
         mode: compression type
         path: where to extract tar contents
     """
-    tmp_fn = None
-    try:
-        if LBZIP2_PATH and mode == "bz2":
-            # fastest bz2 decompressor by far
-            tmp_fd, tmp_fn = tempfile.mkstemp(prefix="fuzzfetch-", suffix=".tar")
-            result = call([LBZIP2_PATH, "-dc", tar_fn], stdout=tmp_fd, stderr=DEVNULL)
-            os.close(tmp_fd)
-            if result == 0:
-                mode = ""
-                tar_fn = tmp_fn
-            else:
-                LOG.warning(
-                    "lbzip2 was found, but returned %d decompressing %r", result, tar_fn
-                )
-
-        elif TAR_PATH and mode == "gz":
-            # this is faster than gunzip somehow
-            tmp_fd, tmp_fn = tempfile.mkstemp(prefix="fuzzfetch-", suffix=".tar")
-            with gzip.open(tar_fn) as gz_fp, open(tmp_fd, "wb") as tmp_fp:
-                shutil.copyfileobj(gz_fp, tmp_fp)
-            mode = ""
-            tar_fn = tmp_fn
-
+    tar_args: list[str] = []
+    external_decomp: str | None = None
+    if mode == "bz2":
+        # lbzip2 > bzip2
         if TAR_PATH:
-            Path(path).mkdir(exist_ok=True)
-            cmd = [TAR_PATH, r"--transform=s,^firefox/,,", "-C", str(path)]
-            if mode:
-                cmd.append(
-                    {
-                        "gz": "-z",
-                        "bz2": "-j",
-                        "lzma": "--lzma",
-                        "xz": "-J",
-                    }.get(mode, "--auto-compress")
-                )
-            cmd.extend(("-xf", str(tar_fn)))
-            check_call(cmd)
+            if LBZIP2_PATH:
+                tar_args.extend(("-I", LBZIP2_PATH))
+            else:
+                tar_args.append("-j")
+            mode = ""
+        elif LBZIP2_PATH:
+            external_decomp = LBZIP2_PATH
+            mode = ""
+
+    elif mode == "xz":
+        # xz > python
+        if TAR_PATH and XZ_PATH:
+            tar_args.append("-J")
+            mode = ""
+        elif XZ_PATH:
+            external_decomp = XZ_PATH
+            mode = ""
+
+    if TAR_PATH:
+        Path(path).mkdir(exist_ok=True)
+        cmd = [TAR_PATH, r"--transform=s,^firefox/,,", "-C", str(path), *tar_args, "-x"]
+        if mode == "gz":
+            # Python gzip is somehow faster than gunzip
+            #
+            # zcat target.gtest.tests.tar.gz  7.34s user 0.24s system 99% cpu 7.592 tota
+            # tar -tv  0.02s user 0.39s system 5% cpu 7.592 total
+            #
+            # python3 -c   4.63s user 0.37s system 99% cpu 4.998 total
+            # tar -tv  0.04s user 0.22s system 5% cpu 4.995 total
+            with gzip.open(tar_fn) as gz_fp, Popen(cmd, stdin=PIPE) as tar_proc:
+                assert tar_proc.stdin is not None
+                shutil.copyfileobj(gz_fp, tar_proc.stdin)
+            if rc := tar_proc.wait():
+                raise CalledProcessError(returncode=rc, cmd=cmd)
+
+        elif mode == "xz":
+            # no external xz, use Python
+            with lzma.open(tar_fn) as xz_fp:
+                run(cmd, check=True, stdin=xz_fp)
+        else:
+            cmd.extend(("-f", str(tar_fn)))
+            run(cmd, check=True, env={"XZ_DEFAULTS": "-T0"})
+    else:
+
+        def _extract_tar(tar: tarfile.TarFile) -> None:
+            members = []
+            for member in tar.getmembers():
+                if not _is_within_directory(path, Path(path) / member.name):
+                    raise RuntimeError("Attempted Path Traversal in Tar File")
+                if member.name.startswith("firefox/"):
+                    member.name = member.name[8:]
+                    members.append(member)
+                elif member.name != "firefox":
+                    # Ignore top-level build directory
+                    members.append(member)
+            tar.extractall(members=members, path=path)
+
+        if external_decomp:
+            cmd = [external_decomp, "-dc", str(tar_fn)]
+            with Popen(
+                cmd, env={"XZ_DEFAULTS": "-T0"}, stdout=PIPE
+            ) as decomp, tarfile.open(fileobj=decomp.stdout, mode="r|") as tar:
+                _extract_tar(tar)
+            if rc := decomp.wait():
+                raise CalledProcessError(returncode=rc, cmd=cmd)
         else:
             with tarfile.open(tar_fn, mode=f"r:{mode}") as tar:
-                members = []
-                for member in tar.getmembers():
-                    if not _is_within_directory(path, Path(path) / member.name):
-                        raise RuntimeError("Attempted Path Traversal in Tar File")
-                    if member.name.startswith("firefox/"):
-                        member.name = member.name[8:]
-                        members.append(member)
-                    elif member.name != "firefox":
-                        # Ignore top-level build directory
-                        members.append(member)
-                tar.extractall(members=members, path=path)
-    finally:
-        if tmp_fn is not None:
-            os.unlink(tmp_fn)
+                _extract_tar(tar)
 
 
 def extract_dmg(dmg_fn: PathArg, path: PathArg = ".") -> None:

--- a/src/fuzzfetch/models.py
+++ b/src/fuzzfetch/models.py
@@ -3,6 +3,8 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 """Fuzzfetch internal models"""
 
+from __future__ import annotations
+
 import itertools
 import platform as std_platform
 from collections.abc import Iterable, Iterator
@@ -10,7 +12,7 @@ from dataclasses import dataclass, fields
 from datetime import datetime
 from enum import Enum
 from logging import getLogger
-from typing import Any, Optional
+from typing import Any
 
 from pytz import timezone
 from requests import RequestException
@@ -106,11 +108,11 @@ class BuildTask:
 
     def __init__(
         self,
-        build: Optional[str],
-        branch: Optional[str],
-        flags: Optional[BuildFlags],
-        platform: Optional["Platform"] = None,
-        simulated: Optional[str] = None,
+        build: str | None,
+        branch: str | None,
+        flags: BuildFlags | None,
+        platform: Platform | None = None,
+        simulated: str | None = None,
         _blank: bool = False,
     ) -> None:
         """Retrieve the task JSON object
@@ -119,8 +121,8 @@ class BuildTask:
         platform
         """
         if _blank:
-            self.url: Optional[str] = None
-            self.queue_server: Optional[str] = None
+            self.url: str | None = None
+            self.queue_server: str | None = None
             self._data: dict[str, Any] = {}
             return
         assert build is not None
@@ -156,9 +158,9 @@ class BuildTask:
         build: str,
         branch: str,
         flags: BuildFlags,
-        platform: Optional["Platform"] = None,
-        simulated: Optional[str] = None,
-    ) -> Iterator["BuildTask"]:
+        platform: Platform | None = None,
+        simulated: str | None = None,
+    ) -> Iterator[BuildTask]:
         """Generator for all possible BuildTasks with these parameters"""
         # Prepare build type
         if platform is None:
@@ -201,7 +203,7 @@ class BuildTask:
                 namespaces_: list[str],
                 prod_: str,
                 suffix_: str,
-                simulated_: Optional[str],
+                simulated_: str | None,
             ) -> Iterator[str]:
                 for namespace in namespaces_:
                     if simulated_ is not None:
@@ -381,8 +383,8 @@ class Platform:
 
     def __init__(
         self,
-        system: Optional[str] = None,
-        machine: Optional[str] = None,
+        system: str | None = None,
+        machine: str | None = None,
     ) -> None:
         if system is None:
             system = std_platform.system()
@@ -398,7 +400,7 @@ class Platform:
         self.gecko_platform = self.SUPPORTED[system][fixed_machine]
 
     @classmethod
-    def from_platform_guess(cls, build_string: str) -> "Platform":
+    def from_platform_guess(cls, build_string: str) -> Platform:
         """Create a platform object from a namespace build string"""
         match: list[str] = []
         for system, platform in cls.SUPPORTED.items():

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -54,6 +54,7 @@ def test_zipfile_extract(tmp_path):
 )
 @patch("fuzzfetch.extract.TAR_PATH", None)
 @patch("fuzzfetch.extract.LBZIP2_PATH", None)
+@patch("fuzzfetch.extract.XZ_PATH", None)
 def test_tarfile_good(tmp_path, extension, mode):
     """Test extract_tar with different extensions and TAR_PATH set to None."""
     archive_path = create_test_archive(tmp_path, extension, mode)

--- a/tox.ini
+++ b/tox.ini
@@ -45,14 +45,14 @@ skip_install = true
 commands =
     mypy --install-types --non-interactive {posargs}
 deps =
-    mypy==v1.10.1
+    mypy==v1.13.0
 usedevelop = true
 
 [testenv:pylint]
 commands =
     pylint {posargs}
 deps =
-    pylint==3.2.5
+    pylint==3.3.2
 usedevelop = true
 
 [testenv:pypi]


### PR DESCRIPTION
- Only warn about missing lbzip2 if we would use it
- Add xz warning if we would use it
- Make external xz multi-threaded
- Fall-back to python lzma if xz is not available
- Use pipes in place of temporary files
- Update CI (add Windows/mac) & typing format

Fixes #151, #152, #153