### PR TITLE
Support passing BuildID as a `--build` argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Target:
 
 Build:
   --build DATE|REV|NS   Specify the build to download, (default: latest)
-                        Accepts values in format YYYY-MM-DD (2017-01-01)
-                        revision (57b37213d81150642f5139764e7044b07b9dccc3) or
+                        Accepts values in format YYYY-MM-DD (2017-01-01),
+                        BuildID (20170101120101), revision
+                        (57b37213d81150642f5139764e7044b07b9dccc3), or
                         TaskCluster namespace (gecko.v2....)
 
 Branch:

--- a/src/fuzzfetch/args.py
+++ b/src/fuzzfetch/args.py
@@ -88,8 +88,9 @@ class FetcherArgs:
             default="latest",
             metavar="DATE|REV|NS",
             help="Specify the build to download, (default: %(default)s)"
-            " Accepts values in format YYYY-MM-DD (2017-01-01)"
-            " revision (57b37213d81150642f5139764e7044b07b9dccc3)"
+            " Accepts values in format YYYY-MM-DD (2017-01-01),"
+            " BuildID (20170101120101),"
+            " revision (57b37213d81150642f5139764e7044b07b9dccc3),"
             " or TaskCluster namespace (gecko.v2....)",
         )
 

--- a/src/fuzzfetch/core.py
+++ b/src/fuzzfetch/core.py
@@ -110,7 +110,10 @@ class Fetcher:
                 if "latest" in build:
                     requested = now
                 elif is_date(build):
-                    date = datetime.strptime(build, "%Y-%m-%d")
+                    if "-" in build:
+                        date = datetime.strptime(build, "%Y-%m-%d")
+                    else:
+                        date = datetime.strptime(build, "%Y%m%d%H%M%S")
                     requested = timezone("UTC").localize(date)
                 elif is_rev(build):
                     requested = HgRevision(build, branch).pushdate

--- a/src/fuzzfetch/models.py
+++ b/src/fuzzfetch/models.py
@@ -172,11 +172,18 @@ class BuildTask:
 
         if is_date(build):
             flag_str = flags.build_string()
+            if "-" in build:
+                build_date_ns = build.replace("-", ".")
+                filt = ""
+            else:
+                build_date_ns = f"{build[:4]}.{build[4:6]}.{build[6:8]}"
+                filt = build
             task_template_paths: Iterable[tuple[str, str]] = tuple(
                 (template, path + flag_str)
                 for (template, path) in cls._pushdate_template_paths(
-                    build.replace("-", "."), branch, target_platform
+                    build_date_ns, branch, target_platform
                 )
+                if filt in path
             )
 
         elif is_rev(build):

--- a/src/fuzzfetch/utils.py
+++ b/src/fuzzfetch/utils.py
@@ -4,6 +4,7 @@
 """Assorted fuzzfetch utilities"""
 
 import re
+from contextlib import suppress
 from datetime import datetime
 
 from pytz import timezone
@@ -31,7 +32,13 @@ def is_date(build: str) -> bool:
     Args:
         build: Build string.
     """
-    return bool(re.match(r"^\d{4}-\d{2}-\d{2}$", build))
+    with suppress(ValueError):
+        datetime.strptime(build, "%Y-%m-%d")
+        return True
+    with suppress(ValueError):
+        datetime.strptime(build, "%Y%m%d%H%M%S")
+        return True
+    return False
 
 
 def is_rev(build: str) -> bool:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from fuzzfetch.utils import is_date, is_namespace, is_rev
     "build, expected_date, expected_rev, expected_namespace",
     [
         ("2024-01-01", True, False, False),  # Date string
+        ("20240101120000", True, False, False),  # build id Date
         ("a1b2c3d4e5f6", False, True, False),  # 12-character rev
         ("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", False, True, False),  # 40-char rev
         (


### PR DESCRIPTION
This means you can pass either a BuildID or SourceStamp to get a specific build, or search older/newer builds.

Fixes #94 