### PR TITLE
Add --skip-crashreporter-symbols flag

### DIFF
--- a/src/fuzzfetch/args.py
+++ b/src/fuzzfetch/args.py
@@ -133,9 +133,9 @@ class FetcherArgs:
         )
 
         misc_group.add_argument(
-            "--skip-crashreporter-symbols",
+            "--include-crashreporter-symbols",
             action="store_true",
-            help="Do not attempt to download crash reporter symbols.",
+            help="Include crash reporter symbols in download.",
         )
 
         near_group = self.parser.add_argument_group(

--- a/src/fuzzfetch/args.py
+++ b/src/fuzzfetch/args.py
@@ -132,6 +132,12 @@ class FetcherArgs:
             help="Search for build and output metadata only, don't download anything.",
         )
 
+        misc_group.add_argument(
+            "--skip-crashreporter-symbols",
+            action="store_true",
+            help="Do not attempt to download crash reporter symbols.",
+        )
+
         near_group = self.parser.add_argument_group(
             "Near Arguments",
             "If the specified build isn't found, iterate over "

--- a/src/fuzzfetch/core.py
+++ b/src/fuzzfetch/core.py
@@ -58,6 +58,7 @@ class Fetcher:
         platform: Platform | None = None,
         simulated: str | None = None,
         nearest: BuildSearchOrder | None = None,
+        skip_crashreporter_symbols: bool = False
     ) -> None:
         """
         Arguments:
@@ -79,6 +80,7 @@ class Fetcher:
         self._simulated = simulated
         self._targets = targets
         self._task = None
+        self._skip_crashreporter_symbols = skip_crashreporter_symbols
 
         if not isinstance(build, BuildTask):
             if is_namespace(build):
@@ -390,6 +392,7 @@ class Fetcher:
                 not self._flags.asan
                 and not self._flags.tsan
                 and not self._flags.valgrind
+                and not self._skip_crashreporter_symbols
             ):
                 try:
                     resolve_url(self.artifact_url("crashreporter-symbols.zip"))
@@ -500,6 +503,7 @@ class Fetcher:
                 not self._flags.asan
                 and not self._flags.tsan
                 and not self._flags.valgrind
+                and not self._skip_crashreporter_symbols
             ):
                 if self._platform.system == "Darwin":
                     sym_path = next(path.glob("*.app/Contents/MacOS")) / "symbols"
@@ -720,6 +724,7 @@ class Fetcher:
             platform=Platform(args.os, args.cpu),
             simulated=args.sim,
             nearest=args.nearest,
+            skip_crashreporter_symbols=args.skip_crashreporter_symbols,
         )
 
         if args.name is None:

--- a/src/fuzzfetch/core.py
+++ b/src/fuzzfetch/core.py
@@ -58,7 +58,7 @@ class Fetcher:
         platform: Platform | None = None,
         simulated: str | None = None,
         nearest: BuildSearchOrder | None = None,
-        skip_crashreporter_symbols: bool = False
+        include_crashreporter_symbols: bool = False
     ) -> None:
         """
         Arguments:
@@ -80,7 +80,7 @@ class Fetcher:
         self._simulated = simulated
         self._targets = targets
         self._task = None
-        self._skip_crashreporter_symbols = skip_crashreporter_symbols
+        self._include_crashreporter_symbols = include_crashreporter_symbols
 
         if not isinstance(build, BuildTask):
             if is_namespace(build):
@@ -392,7 +392,7 @@ class Fetcher:
                 not self._flags.asan
                 and not self._flags.tsan
                 and not self._flags.valgrind
-                and not self._skip_crashreporter_symbols
+                and self._include_crashreporter_symbols
             ):
                 try:
                     resolve_url(self.artifact_url("crashreporter-symbols.zip"))
@@ -503,7 +503,7 @@ class Fetcher:
                 not self._flags.asan
                 and not self._flags.tsan
                 and not self._flags.valgrind
-                and not self._skip_crashreporter_symbols
+                and self._include_crashreporter_symbols
             ):
                 if self._platform.system == "Darwin":
                     sym_path = next(path.glob("*.app/Contents/MacOS")) / "symbols"
@@ -724,7 +724,7 @@ class Fetcher:
             platform=Platform(args.os, args.cpu),
             simulated=args.sim,
             nearest=args.nearest,
-            skip_crashreporter_symbols=args.skip_crashreporter_symbols,
+            include_crashreporter_symbols=args.include_crashreporter_symbols,
         )
 
         if args.name is None:


### PR DESCRIPTION
This allows us to skip downloading crashreporter symbols for cases where we don't need them (e.g. for bisections or for fuzzing that doesn't use the symbols).