### PR TITLE
feat: export product class

### DIFF
--- a/src/fuzzfetch/__init__.py
+++ b/src/fuzzfetch/__init__.py
@@ -7,7 +7,7 @@ from .args import FetcherArgs  # noqa
 from .core import Fetcher, __version__  # noqa
 from .download import download_url, get_url, iec, si  # noqa
 from .errors import FetcherException  # noqa
-from .models import BuildFlags, BuildSearchOrder, BuildTask, Platform  # noqa
+from .models import BuildFlags, BuildSearchOrder, BuildTask, Platform, Product  # noqa
 from .utils import is_date, is_namespace, is_rev  # noqa
 
 __author__ = "Jesse Schwartzentruber, Jason Kratzer"


### PR DESCRIPTION
Required to use `BuildTask.iterall`.